### PR TITLE
fixed float type inputs

### DIFF
--- a/src/components/pages/Wallet/components/AssetIssueForm/index.tsx
+++ b/src/components/pages/Wallet/components/AssetIssueForm/index.tsx
@@ -223,7 +223,7 @@ const AssetIssueForm = ({
                           className={cn('form-control', {
                             'is-invalid': meta.touched && meta.error,
                           })}
-                          type="number"
+                          type="float"
                           placeholder="Minimum 0.001 ERG"
                           {...input}
                         />

--- a/src/components/pages/Wallet/components/PaymentSendForm/index.tsx
+++ b/src/components/pages/Wallet/components/PaymentSendForm/index.tsx
@@ -249,7 +249,7 @@ const PaymentSendForm = ({
                                   className={cn('form-control', {
                                     'is-invalid': meta.touched && meta.error,
                                   })}
-                                  type="number"
+                                  type="float"
                                   placeholder="0,000"
                                   {...input}
                                 />
@@ -273,7 +273,7 @@ const PaymentSendForm = ({
                             className={cn('form-control', {
                               'is-invalid': meta.touched && meta.error,
                             })}
-                            type="number"
+                            type="float"
                             placeholder="Minimum 0.001 ERG"
                             {...input}
                           />


### PR DESCRIPTION
Fixed problem input type in wallet page (this problem existed on Safari)

<img width="272" alt="Screen Shot 2022-01-09 at 2 50 01 PM" src="https://user-images.githubusercontent.com/35424774/148680044-3858d0d2-e799-4a7c-a8f6-ae66c2c90af1.png">
